### PR TITLE
[SNOWLAKE-30] Refine static polymorphism implementation in ArgumentParser

### DIFF
--- a/src/ArgumentParser.cpp
+++ b/src/ArgumentParser.cpp
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 
 #include "ArgumentParser.h"
+#include "variant_static_visitor.h"
 #include "version.h"
 #include <sstream>
 #include <string>
@@ -492,32 +493,38 @@ ArgumentParser::__defined_boolean_option(const std::string& name) const
 
 // -----------------------------------------------------------------------------
 
-template <typename T>
-void
-ArgumentParser::CmdlOption::__update_value(const std::string& new_value)
+struct CmdlOptionValueCast : public sl::variant::static_visitor<ArgumentParser::value_type>
 {
-  T val;
-  std::stringstream ss(new_value);
-  ss >> val;
-  value.value = val;
-}
+  explicit CmdlOptionValueCast(const std::string& raw_value) :
+    m_raw_value(raw_value)
+  {
+  }
+
+  ~CmdlOptionValueCast() {}
+
+  template <typename T>
+  T operator()(T&) {
+    T val;
+    std::stringstream ss(m_raw_value);
+    ss >> val;
+    return val;
+  }
+
+  std::string operator()(std::string&) {
+    return m_raw_value;
+  }
+
+  private:
+    const std::string& m_raw_value;
+};
 
 // -----------------------------------------------------------------------------
 
 void
 ArgumentParser::CmdlOption::update_value(const std::string& new_value)
 {
-  if (default_value.value.is<std::string>()) {
-    value.value = new_value;
-  } else if (default_value.value.is<uint32_t>()) {
-    __update_value<uint32_t>(new_value);
-  } else if (default_value.value.is<uint64_t>()) {
-    __update_value<uint64_t>(new_value);
-  } else if (default_value.value.is<float>()) {
-    __update_value<float>(new_value);
-  } else if (default_value.value.is<double>()) {
-    __update_value<double>(new_value);
-  }
+  CmdlOptionValueCast cast(new_value);
+  value.value = sl::variant::apply_visitor(cast, default_value.value); 
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ArgumentParser.cpp
+++ b/src/ArgumentParser.cpp
@@ -493,29 +493,34 @@ ArgumentParser::__defined_boolean_option(const std::string& name) const
 
 // -----------------------------------------------------------------------------
 
-struct CmdlOptionValueCast : public sl::variant::static_visitor<ArgumentParser::value_type>
+struct CmdlOptionValueCast
+    : public sl::variant::static_visitor<ArgumentParser::value_type>
 {
-  explicit CmdlOptionValueCast(const std::string& raw_value) :
-    m_raw_value(raw_value)
+  explicit CmdlOptionValueCast(const std::string& raw_value)
+    : m_raw_value(raw_value)
   {
   }
 
-  ~CmdlOptionValueCast() {}
+  ~CmdlOptionValueCast()
+  {
+  }
 
   template <typename T>
-  T operator()(T&) {
+  T operator()(T&)
+  {
     T val;
     std::stringstream ss(m_raw_value);
     ss >> val;
     return val;
   }
 
-  std::string operator()(std::string&) {
+  std::string operator()(std::string&)
+  {
     return m_raw_value;
   }
 
-  private:
-    const std::string& m_raw_value;
+private:
+  const std::string& m_raw_value;
 };
 
 // -----------------------------------------------------------------------------
@@ -524,7 +529,7 @@ void
 ArgumentParser::CmdlOption::update_value(const std::string& new_value)
 {
   CmdlOptionValueCast cast(new_value);
-  value.value = sl::variant::apply_visitor(cast, default_value.value); 
+  value.value = sl::variant::apply_visitor(cast, default_value.value);
 }
 
 // -----------------------------------------------------------------------------
@@ -550,20 +555,23 @@ ArgumentParser::__assign_values()
 
 // -----------------------------------------------------------------------------
 
-struct CmdlOptionDestinationValueUpdate : public sl::variant::static_visitor<ArgumentParser::value_type>
+struct CmdlOptionDestinationValueUpdate
+    : public sl::variant::static_visitor<ArgumentParser::value_type>
 {
-  CmdlOptionDestinationValueUpdate(
-    const ArgumentParser::value_type& value,
-    void* dst) :
-    m_value(value),
-    m_dst(dst)
+  CmdlOptionDestinationValueUpdate(const ArgumentParser::value_type& value,
+                                   void* dst)
+    : m_value(value)
+    , m_dst(dst)
   {
   }
 
-  ~CmdlOptionDestinationValueUpdate() {}
+  ~CmdlOptionDestinationValueUpdate()
+  {
+  }
 
   template <typename T>
-  T operator()(T& default_value) {
+  T operator()(T& default_value)
+  {
     T* dst_ = reinterpret_cast<T*>(m_dst);
     if (dst_) {
       *dst_ = m_value.valid() ? m_value.get<T>() : default_value;

--- a/src/ArgumentParser.cpp
+++ b/src/ArgumentParser.cpp
@@ -550,32 +550,39 @@ ArgumentParser::__assign_values()
 
 // -----------------------------------------------------------------------------
 
-template <typename T>
-void
-ArgumentParser::CmdlOption::__assign_value_to_dst()
+struct CmdlOptionDestinationValueUpdate : public sl::variant::static_visitor<ArgumentParser::value_type>
 {
-  T* dst_ = reinterpret_cast<T*>(dst);
-  *dst_ = (value.value.valid() ? value.value : default_value.value).get<T>();
-}
+  CmdlOptionDestinationValueUpdate(
+    const ArgumentParser::value_type& value,
+    void* dst) :
+    m_value(value),
+    m_dst(dst)
+  {
+  }
+
+  ~CmdlOptionDestinationValueUpdate() {}
+
+  template <typename T>
+  T operator()(T& default_value) {
+    T* dst_ = reinterpret_cast<T*>(m_dst);
+    if (dst_) {
+      *dst_ = m_value.valid() ? m_value.get<T>() : default_value;
+    }
+    return default_value;
+  }
+
+private:
+  const ArgumentParser::value_type& m_value;
+  void* m_dst;
+};
 
 // -----------------------------------------------------------------------------
 
 void
 ArgumentParser::CmdlOption::assign_value_to_dst()
 {
-  if (default_value.value.is<std::string>()) {
-    __assign_value_to_dst<std::string>();
-  } else if (default_value.value.is<bool>()) {
-    __assign_value_to_dst<bool>();
-  } else if (default_value.value.is<uint32_t>()) {
-    __assign_value_to_dst<uint32_t>();
-  } else if (default_value.value.is<uint64_t>()) {
-    __assign_value_to_dst<uint64_t>();
-  } else if (default_value.value.is<float>()) {
-    __assign_value_to_dst<float>();
-  } else if (default_value.value.is<double>()) {
-    __assign_value_to_dst<double>();
-  }
+  CmdlOptionDestinationValueUpdate update(value.value, dst);
+  sl::variant::apply_visitor(update, default_value.value);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ArgumentParser.h
+++ b/src/ArgumentParser.h
@@ -84,6 +84,9 @@ public:
 
   void print_help() const;
 
+public:
+  using value_type = sl::variant::variant<std::string, uint32_t, uint64_t,
+                                            bool, float, double>;
 private:
   bool __defined_boolean_option(const std::string&) const;
 
@@ -109,8 +112,7 @@ private:
 
   struct CmdlOptionValue
   {
-    using value_type = sl::variant::variant<std::string, uint32_t, uint64_t,
-                                            bool, float, double>;
+    using value_type = ArgumentParser::value_type;
     value_type value;
   };
 
@@ -130,9 +132,6 @@ private:
   private:
     template <typename T>
     void __assign_value_to_dst();
-
-    template <typename T>
-    void __update_value(const std::string&);
   };
 
   using CmdlOptionMap = std::unordered_map<std::string, CmdlOption>;

--- a/src/ArgumentParser.h
+++ b/src/ArgumentParser.h
@@ -128,10 +128,6 @@ private:
     void assign_value_to_dst();
 
     void update_value(const std::string&);
-
-  private:
-    template <typename T>
-    void __assign_value_to_dst();
   };
 
   using CmdlOptionMap = std::unordered_map<std::string, CmdlOption>;

--- a/src/ArgumentParser.h
+++ b/src/ArgumentParser.h
@@ -85,8 +85,9 @@ public:
   void print_help() const;
 
 public:
-  using value_type = sl::variant::variant<std::string, uint32_t, uint64_t,
-                                            bool, float, double>;
+  using value_type = sl::variant::variant<std::string, uint32_t, uint64_t, bool,
+                                          float, double>;
+
 private:
   bool __defined_boolean_option(const std::string&) const;
 

--- a/src/variant_dispatcher.h
+++ b/src/variant_dispatcher.h
@@ -72,12 +72,12 @@ struct dispatcher<F, V, R>
 
   static result_type apply_const(V const&, F)
   {
-    THROW(std::runtime_error("unary dispatch failed"));
+    THROW(std::runtime_error("unary dispatch failed in sl::variant::dispatcher::apply_const"));
   }
 
   static result_type apply(V&, F)
   {
-    THROW(std::runtime_error("unary dispatch failed"));
+    THROW(std::runtime_error("unary dispatch failed sl::variant::dispatcher::apply"));
   }
 };
 

--- a/src/variant_dispatcher.h
+++ b/src/variant_dispatcher.h
@@ -72,12 +72,12 @@ struct dispatcher<F, V, R>
 
   static result_type apply_const(V const&, F)
   {
-    THROW(std::runtime_error("unary dispatch failed in sl::variant::dispatcher::apply_const"));
+    THROW(std::runtime_error("unary dispatch failed"));
   }
 
   static result_type apply(V&, F)
   {
-    THROW(std::runtime_error("unary dispatch failed sl::variant::dispatcher::apply"));
+    THROW(std::runtime_error("unary dispatch failed"));
   }
 };
 

--- a/unittests/ArgumentParserTests.cpp
+++ b/unittests/ArgumentParserTests.cpp
@@ -371,6 +371,60 @@ TEST_F(ArgumentParserTests,
 
 // -----------------------------------------------------------------------------
 
+TEST_F(ArgumentParserTests,
+       TestParseWithSelectOptionsInBothFormsFormAndPositionalArguments)
+{
+  ArgumentParser argparser;
+  std::string str_dst;
+  uint32_t uint32_dst = 0;
+  uint64_t uint64_dst = 0;
+  bool bool_dst = false;
+  float float_dst = 0.0f;
+  double double_dst = 0.0;
+  const const char* str_default_value = "Hello";
+  const uint64_t uint64_default_value = 64;
+  const bool boolean_default_value = true;
+  const double double_default_value = 2.71828;
+  const char* input_path = "/tmp/hellworld";
+
+  argparser.add_string_parameter("str", 's', "String value", false, &str_dst,
+                                /* default_val */ str_default_value);
+  argparser.add_uint32_parameter("uint32", 'u', "UInt32 value", true,
+                                 &uint32_dst);
+  argparser.add_uint64_parameter("uint64", 'n', "UInt64 value", false,
+                                 &uint64_dst, /* default_val */ uint64_default_value);
+  argparser.add_boolean_parameter("bool", 'b', "Boolean value", false,
+                                  &bool_dst, /* default_val */ boolean_default_value);
+  argparser.add_float_parameter("float", 'f', "Float value", true, &float_dst);
+  argparser.add_double_parameter("double", 'd', "Double value", false,
+                                 &double_dst, /* default_val */ double_default_value);
+
+  const std::vector<char*> args{"MyProgram",
+                                "-u",
+                                "32",
+                                "--float",
+                                "3.14",
+                                const_cast<char*>(input_path)};
+
+  bool res = argparser.parse_args(args.size(), (char**)args.data());
+  ASSERT_TRUE(res);
+
+  ASSERT_STREQ(str_default_value, str_dst.c_str());
+  ASSERT_EQ(32, uint32_dst);
+  ASSERT_EQ(uint64_default_value, uint64_dst);
+  ASSERT_EQ(boolean_default_value, bool_dst);
+  ASSERT_DOUBLE_EQ(3.14f, float_dst);
+  ASSERT_DOUBLE_EQ(double_default_value, double_dst);
+
+  // Check positional argument.
+  const auto& positional_args = argparser.positional_args();
+  ASSERT_FALSE(positional_args.empty());
+  ASSERT_EQ(1, positional_args.size());
+  ASSERT_STREQ(input_path, positional_args.front().c_str());
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(ArgumentParserTests, TestWithDuplicateShorthandlCmdlOptions)
 {
   ArgumentParser argparser("My Program", "1.0.0", "This is a test program.");

--- a/unittests/ArgumentParserTests.cpp
+++ b/unittests/ArgumentParserTests.cpp
@@ -204,7 +204,7 @@ TEST_F(ArgumentParserTests, TestParseWithAllOptionTypesAndDefaultValues)
 
 // -----------------------------------------------------------------------------
 
-TEST_F(ArgumentParserTests, TestParseWithAllOptionlAndPositionalArguments)
+TEST_F(ArgumentParserTests, TestParseWithAllOptionalAndPositionalArguments)
 {
   ArgumentParser argparser;
   std::string str_dst;
@@ -260,7 +260,7 @@ TEST_F(ArgumentParserTests, TestParseWithAllOptionlAndPositionalArguments)
 // -----------------------------------------------------------------------------
 
 TEST_F(ArgumentParserTests,
-       TestParseWithAllOptionlInShorthandFormAndPositionalArguments)
+       TestParseWithAllOptionsInShorthandFormAndPositionalArguments)
 {
   ArgumentParser argparser;
   std::string str_dst;
@@ -316,7 +316,7 @@ TEST_F(ArgumentParserTests,
 // -----------------------------------------------------------------------------
 
 TEST_F(ArgumentParserTests,
-       TestParseWithAllOptionlInBothFormsFormAndPositionalArguments)
+       TestParseWithAllOptionsInBothFormsAndPositionalArguments)
 {
   ArgumentParser argparser;
   std::string str_dst;
@@ -372,7 +372,7 @@ TEST_F(ArgumentParserTests,
 // -----------------------------------------------------------------------------
 
 TEST_F(ArgumentParserTests,
-       TestParseWithSelectOptionsInBothFormsFormAndPositionalArguments)
+       TestParseWithSelectOptionsInBothFormsAndPositionalArguments)
 {
   ArgumentParser argparser;
   std::string str_dst;

--- a/unittests/ArgumentParserTests.cpp
+++ b/unittests/ArgumentParserTests.cpp
@@ -388,23 +388,23 @@ TEST_F(ArgumentParserTests,
   const char* input_path = "/tmp/hellworld";
 
   argparser.add_string_parameter("str", 's', "String value", false, &str_dst,
-                                /* default_val */ str_default_value);
+                                 /* default_val */ str_default_value);
   argparser.add_uint32_parameter("uint32", 'u', "UInt32 value", true,
                                  &uint32_dst);
   argparser.add_uint64_parameter("uint64", 'n', "UInt64 value", false,
-                                 &uint64_dst, /* default_val */ uint64_default_value);
+                                 &uint64_dst,
+                                 /* default_val */ uint64_default_value);
   argparser.add_boolean_parameter("bool", 'b', "Boolean value", false,
-                                  &bool_dst, /* default_val */ boolean_default_value);
+                                  &bool_dst,
+                                  /* default_val */ boolean_default_value);
   argparser.add_float_parameter("float", 'f', "Float value", true, &float_dst);
   argparser.add_double_parameter("double", 'd', "Double value", false,
-                                 &double_dst, /* default_val */ double_default_value);
+                                 &double_dst,
+                                 /* default_val */ double_default_value);
 
-  const std::vector<char*> args{"MyProgram",
-                                "-u",
-                                "32",
-                                "--float",
-                                "3.14",
-                                const_cast<char*>(input_path)};
+  const std::vector<char*> args{"MyProgram", "-u",
+                                "32",        "--float",
+                                "3.14",      const_cast<char*>(input_path)};
 
   bool res = argparser.parse_args(args.size(), (char**)args.data());
   ASSERT_TRUE(res);


### PR DESCRIPTION
This patch improves the implementations of various static polymorphism implementation inside of `ArgumentParser`.

Specifically, the static visitor pattern of `sl::variant` is used here to implement default value cast and  update, as well as the final update/write to the destination pointer for each option.

Also fixes some typos in `ArgumentParserTests`.